### PR TITLE
Add test coverage analysis.

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -22,4 +22,4 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./src/Atrea.Extensions.Tests/TestResults/coverage.info
+        path-to-lcov: ./src/Atrea.Utilities.Tests/TestResults/coverage.info

--- a/src/Atrea.Utilities.Tests/Atrea.Utilities.Tests.csproj
+++ b/src/Atrea.Utilities.Tests/Atrea.Utilities.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />


### PR DESCRIPTION
Adding `coverlet.msbuild` to test project to allow for
test coverage analysis and report generation.